### PR TITLE
Update archive type

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,7 +12,7 @@ license=('GPL')
 optdepends=('gtk-engine-murrine: gtk2 theme support'
             'elementary-icon-theme: icons support'
             'gtk-engine-unico: gtk3 theme support')
-source=("http://archive.ubuntu.com/ubuntu/pool/universe/l/${pkgname}/${pkgname}_${pkgver}.tar.gz")
+source=("http://archive.ubuntu.com/ubuntu/pool/universe/l/${pkgname}/${pkgname}_${pkgver}.tar.xz")
 sha256sums=('fe0161a2a9b00211c35c0c1acc3915040513b3db8cddda7aa643a9b6e2d6ca96')
 
 package(){


### PR DESCRIPTION
V0.55 is compressed with xz, not gz.
